### PR TITLE
Modify path attribute in routing json output

### DIFF
--- a/docs/api/get_route.md
+++ b/docs/api/get_route.md
@@ -27,7 +27,7 @@
 {"route":{
   "length":139.55322,
   "duration":10,
-  "paths":[374121070,259075831,37517506],
+  "paths":{"segmentId":374121070,"direction":true},{"segmentId":259075831,"direction":true},{"segmentId":37517506,"direction":true},
   "runtimeInMs":11,
   "graphName":"osm_at_lower_levels",
   "graphVersion":null,

--- a/docs/api/get_route.md
+++ b/docs/api/get_route.md
@@ -27,7 +27,7 @@
 {"route":{
   "length":139.55322,
   "duration":10,
-  "paths":{"segmentId":374121070,"direction":true},{"segmentId":259075831,"direction":true},{"segmentId":37517506,"direction":true},
+  "paths":[{"segmentId":374121070,"direction":true},{"segmentId":259075831,"direction":true},{"segmentId":37517506,"direction":true}],
   "runtimeInMs":11,
   "graphName":"osm_at_lower_levels",
   "graphVersion":null,

--- a/routing-neo4j/src/main/java/at/srfg/graphium/routing/model/IPathSegment.java
+++ b/routing-neo4j/src/main/java/at/srfg/graphium/routing/model/IPathSegment.java
@@ -1,6 +1,6 @@
 /**
  * Graphium Neo4j - Module of Graphium for routing services via Neo4j
- * Copyright © 2017 Salzburg Research Forschungsgesellschaft (graphium@salzburgresearch.at)
+ * Copyright © 2018 Salzburg Research Forschungsgesellschaft (graphium@salzburgresearch.at)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,30 +17,9 @@
  */
 package at.srfg.graphium.routing.model;
 
-import java.util.List;
-
-import at.srfg.graphium.model.IWaySegment;
-
-public interface IRoute<T extends IWaySegment> {
-
-	float getLength();
-	void setLength(float length);
-	
-	public int getDuration();
-	public void setDuration(int duration);
-	
-	public List<IPathSegment> getPath();
-	public void setPath(List<IPathSegment> path);
-	
-	public List<T> getSegments();
-	public void setSegments(List<T> segments);
-
-	public int getRuntimeInMs();
-	public void setRuntimeInMs(int runtimeInMs);
-	
-	public String getGraphName();
-	public void setGraphName(String graphName);
-	
-	public String getGraphVersion();
-	public void setGraphVersion(String graphVersion);
+public interface IPathSegment {
+	long getSegmentId();
+	void setSegmentId(long segment);
+	boolean isDirection();
+	void setDirection(boolean direction);
 }

--- a/routing-neo4j/src/main/java/at/srfg/graphium/routing/model/dto/impl/RouteDtoImpl.java
+++ b/routing-neo4j/src/main/java/at/srfg/graphium/routing/model/dto/impl/RouteDtoImpl.java
@@ -20,18 +20,19 @@ package at.srfg.graphium.routing.model.dto.impl;
 import java.util.List;
 
 import at.srfg.graphium.model.IWaySegment;
+import at.srfg.graphium.routing.model.IPathSegment;
 
 public class RouteDtoImpl<T extends IWaySegment>  {
 
 	private float length;
 	private int duration;
-	private List<Long> paths;
+	private List<IPathSegment> paths;
 	private int runtimeInMs;
 	private String graphName;
 	private String graphVersion;
 	private String geometry;
 
-	public RouteDtoImpl(float length, int duration, List<Long> paths, int runtimeInMs, String graphName,
+	public RouteDtoImpl(float length, int duration, List<IPathSegment> paths, int runtimeInMs, String graphName,
 			String graphVersion, String geometry) {
 		super();
 		this.length = length;
@@ -43,11 +44,11 @@ public class RouteDtoImpl<T extends IWaySegment>  {
 		this.geometry = geometry;
 	}
 
-	public List<Long> getPaths() {
+	public List<IPathSegment> getPaths() {
 		return paths;
 	}
 
-	public void setPaths(List<Long> paths) {
+	public void setPaths(List<IPathSegment> paths) {
 		this.paths = paths;
 	}
 

--- a/routing-neo4j/src/main/java/at/srfg/graphium/routing/model/impl/PathSegmentImpl.java
+++ b/routing-neo4j/src/main/java/at/srfg/graphium/routing/model/impl/PathSegmentImpl.java
@@ -1,0 +1,43 @@
+/**
+ * Graphium Neo4j - Module of Graphium for routing services via Neo4j
+ * Copyright © 2018 Salzburg Research Forschungsgesellschaft (graphium@salzburgresearch.at)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package at.srfg.graphium.routing.model.impl;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import at.srfg.graphium.routing.model.IPathSegment;
+
+public class PathSegmentImpl implements IPathSegment{
+	@JsonProperty(value="segment")
+	private long segmentId;
+	@JsonProperty(value="direction")
+	private boolean direction;
+	
+	
+	public long getSegmentId() {
+		return segmentId;
+	}
+	public void setSegmentId(long segmentId) {
+		this.segmentId = segmentId;
+	}
+	public boolean isDirection() {
+		return direction;
+	}
+	public void setDirection(boolean direction) {
+		this.direction = direction;
+	}
+}

--- a/routing-neo4j/src/main/java/at/srfg/graphium/routing/model/impl/RouteImpl.java
+++ b/routing-neo4j/src/main/java/at/srfg/graphium/routing/model/impl/RouteImpl.java
@@ -24,6 +24,7 @@ import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 import at.srfg.graphium.model.IWaySegment;
+import at.srfg.graphium.routing.model.IPathSegment;
 import at.srfg.graphium.routing.model.IRoute;
 
 public class RouteImpl<T extends IWaySegment> implements IRoute<T>, Serializable{
@@ -34,7 +35,7 @@ public class RouteImpl<T extends IWaySegment> implements IRoute<T>, Serializable
 	private static final long serialVersionUID = 1L;
 	
 	@JsonProperty(value="Path")
-	private List<Long> path;
+	private List<IPathSegment> path;
 	@JsonProperty(value="Length")
 	private float length;
 	@JsonProperty(value="Duration")
@@ -51,7 +52,7 @@ public class RouteImpl<T extends IWaySegment> implements IRoute<T>, Serializable
 	private String graphVersion;
 
 	public RouteImpl() {}
-	public RouteImpl(List<Long> path, float length, int duration, String error) {
+	public RouteImpl(List<IPathSegment> path, float length, int duration, String error) {
 		this.path = path;
 		this.length = length;
 		this.duration = duration;
@@ -59,7 +60,7 @@ public class RouteImpl<T extends IWaySegment> implements IRoute<T>, Serializable
 	}
 	
 	@Override
-	public List<Long> getPath() {
+	public List<IPathSegment> getPath() {
 		return path;
 	}
 
@@ -74,7 +75,7 @@ public class RouteImpl<T extends IWaySegment> implements IRoute<T>, Serializable
 	}
 
 	@Override
-	public void setPath(List<Long> path) {
+	public void setPath(List<IPathSegment> path) {
 		this.path = path;
 	}
 

--- a/routing-neo4j/src/main/java/at/srfg/graphium/routing/service/neo4j/impl/Neo4jRoutingServiceImpl.java
+++ b/routing-neo4j/src/main/java/at/srfg/graphium/routing/service/neo4j/impl/Neo4jRoutingServiceImpl.java
@@ -54,9 +54,11 @@ import at.srfg.graphium.neo4j.persistence.INeo4jWayGraphReadDao;
 import at.srfg.graphium.neo4j.persistence.configuration.IGraphDatabaseProvider;
 import at.srfg.graphium.neo4j.persistence.impl.Neo4jWaySegmentHelperImpl;
 import at.srfg.graphium.neo4j.persistence.nodemapper.INeo4jNodeMapper;
+import at.srfg.graphium.routing.model.IPathSegment;
 import at.srfg.graphium.routing.model.IRoute;
 import at.srfg.graphium.routing.model.IRouteModelFactory;
 import at.srfg.graphium.routing.model.IRoutingOptions;
+import at.srfg.graphium.routing.model.impl.PathSegmentImpl;
 import at.srfg.graphium.routing.model.impl.RoutingAlgorithms;
 import at.srfg.graphium.routing.model.impl.RoutingMode;
 import at.srfg.graphium.routing.neo4j.evaluators.INeo4jCostEvaluatorFactory;
@@ -224,14 +226,16 @@ public class Neo4jRoutingServiceImpl<T extends IWaySegment>
 		if (weightedPath != null) {
 			float length = 0;
 			int time = 0;
-			List<Long> path = new ArrayList<Long>();
+			List<IPathSegment> path = new ArrayList<IPathSegment>();
 			List<T> segments = new ArrayList<T>();
 			T segment;
 			
 			T prevSegment = null;
 			for (Node node : weightedPath.nodes()) {
 				segment = nodeMapper.map(node);
-				path.add(segment.getId());
+				IPathSegment pathSegment = new PathSegmentImpl();
+				pathSegment.setSegmentId(segment.getId());
+				path.add(pathSegment);
 				segments.add(segment);
 				length = length + segment.getLength();
 				// calculate duration
@@ -239,6 +243,7 @@ public class Neo4jRoutingServiceImpl<T extends IWaySegment>
 					boolean directionTow = prevSegment.getEndNodeId()   == segment.getStartNodeId() || 
 										   prevSegment.getStartNodeId() == segment.getStartNodeId();
 					time = time + segment.getDuration(directionTow);
+					pathSegment.setDirection(directionTow);
 				}
 				prevSegment = segment;
 			}

--- a/routing-neo4j/src/main/java/at/srfg/graphium/routing/service/neo4j/impl/Neo4jRoutingServiceImpl.java
+++ b/routing-neo4j/src/main/java/at/srfg/graphium/routing/service/neo4j/impl/Neo4jRoutingServiceImpl.java
@@ -231,6 +231,8 @@ public class Neo4jRoutingServiceImpl<T extends IWaySegment>
 			T segment;
 			
 			T prevSegment = null;
+			IPathSegment prevPathSegment = null;
+			int i = 0;
 			for (Node node : weightedPath.nodes()) {
 				segment = nodeMapper.map(node);
 				IPathSegment pathSegment = new PathSegmentImpl();
@@ -244,18 +246,27 @@ public class Neo4jRoutingServiceImpl<T extends IWaySegment>
 										   prevSegment.getStartNodeId() == segment.getStartNodeId();
 					time = time + segment.getDuration(directionTow);
 					pathSegment.setDirection(directionTow);
+					
+					if (i == 1) { //Calculate attributes of first segment
+						directionTow = prevSegment.getEndNodeId() == segment.getEndNodeId()
+								|| prevSegment.getEndNodeId() == segment.getStartNodeId();
+						time = time + prevSegment.getDuration(directionTow);
+						prevPathSegment.setDirection(directionTow);
+					}
 				}
 				prevSegment = segment;
+				prevPathSegment = pathSegment;
+				i++;
 			}
-			// calculate duration for first segment
-			if (!segments.isEmpty()) {
-				boolean directionTow = true;
-				if (segments.size() > 1) {
-					directionTow = segments.get(1).getEndNodeId()   == segments.get(0).getEndNodeId() || 
-								   segments.get(1).getStartNodeId() == segments.get(0).getEndNodeId();
-				}
-				time = time + segments.get(0).getDuration(directionTow);
-			}
+//			// calculate duration for first segment
+//			if (!segments.isEmpty()) {
+//				boolean directionTow = true;
+//				if (segments.size() > 1) {
+//					directionTow = segments.get(1).getEndNodeId()   == segments.get(0).getEndNodeId() || 
+//								   segments.get(1).getStartNodeId() == segments.get(0).getEndNodeId();
+//				}
+//				time = time + segments.get(0).getDuration(directionTow);
+//			}
 			
 			route = modelFactory.newRoute();
 			route.setPath(path);


### PR DESCRIPTION
Adds direction for each segment_id in json output:

Old: "paths":[374121070,259075831,37517506]
New: "paths":[{"segmentId":374121070,"direction":true},{"segmentId":259075831,"direction":true},{"segmentId":37517506,"direction":true}]

Docs also updated!